### PR TITLE
we will have the ability to get detailed game seeds once we figure so…

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,10 +8,14 @@
 require 'json'
 require 'open-uri'
 
+List.destroy_all
+User.destroy_all
+
 if ENV['minimal'] == 'yes'
   Game.destroy_all
 
-  url = "https://api.rawg.io/api/games?key=#{ENV[RAWG_API]}"
+
+  url = "https://api.rawg.io/api/games?key=#{ENV['RAWG_API']}"
   doc = URI.parse(url).open.read
   response = JSON.parse(doc)
   games = response['results']
@@ -24,7 +28,35 @@ if ENV['minimal'] == 'yes'
     this.save
     p this.title
   end
-end
+
+  # the following will do 21 api calls, please don't do until it's on heroku and we're not likely to put any more
+  if ENV['detailed'] == 'yes'
+    Game.destroy_all
+
+
+    url = "https://api.rawg.io/api/games?key=#{ENV['RAWG_API']}"
+    doc = URI.parse(url).open.read
+    response = JSON.parse(doc)
+    results = response['results']
+    results.take(20).each do |result|
+      # can get more game info at "https://api.rawg.io/api/games/#{game['id']}?key=#{ENV['RAWG_API']}"
+      game_url =  "https://api.rawg.io/api/games/#{result['id']}?key=#{ENV['RAWG_API']}"
+      game_doc = URI.parse(game_url).open.read
+      game = JSON.parse(game_doc)
+      # details has two or more developers usually so loop through (detailed) game['developers'].each |dev| and put the dev['name'] into an array
+      developers = []
+      game['developers'].each { |dev| developers << dev['name'] }
+      # should probably join all of them by comma, no space maybe
+      # if using detailed game all keys are the same, 'description' gives a description with p tags and breaks 'description_raw' has breaks but no html
+      genres = []
+      game['genres'].each { |genre| genres << genre['name'] }
+      platforms = []
+      game['platforms'].each { |platform| platforms << platform['platform']['name'] }
+      # add   description: game['description_raw']    after migrating
+      this = Game.new(title: game['name'], genre: genres.join(","), developer: developers.join(','), console: platforms.join(","), price: 3.5, release_date: game['released'], image_url: game['background_image'])
+      this.save
+      p this.title
+  end
 
 puts 'Makin that seedy boi'
 


### PR DESCRIPTION
This adds an option to seed more game details which will give us the developers and the description (which we will need to make a migration for) it makes 21 API calls so this is something we should really only do after we've made our heroku and are fairly sure we won't really need to use the API much more. We can use filler text for game descriptions before heroku.